### PR TITLE
Allow installation in PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "illuminate/support": "^5.7|^6.0|^7.0|^8.0",
-        "php": "^7.2"
+        "php": "^7.2|^8.0"
     },
     "require-dev": {
         "orchestra/testbench": "^3.7|^4.0"


### PR DESCRIPTION
Hi there!

The current requirements limits this from being installed on PHP 8 but works fine under testing. This PR just adds PHP 8 as a possible version to use this on.